### PR TITLE
Work around changing v3 primary group

### DIFF
--- a/plugins/mxruntime_
+++ b/plugins/mxruntime_
@@ -2,9 +2,15 @@
 import pwd
 import os
 import sys
+import logging
 import m2ee
 
-m2ee.logger.setLevel(51)
+logger = logging.getLogger()
+logger.setLevel(logging.WARNING)
+consolelogformatter = logging.Formatter("%(levelname)s: %(message)s")
+stderrlog = logging.StreamHandler(sys.stderr)
+stderrlog.setFormatter(consolelogformatter)
+logger.addHandler(stderrlog)
 
 try:
     command = sys.argv[1]

--- a/plugins/mxruntime_
+++ b/plugins/mxruntime_
@@ -1,9 +1,50 @@
 #!/usr/bin/python
-import pwd
+import grp
 import os
+import pwd
 import sys
-import logging
-import m2ee
+
+# Allow this plugin to work with munin plugin conf either set to the actual
+# correct user and group, or as root, in which case we're gonna find out what
+# to do right now right here.
+if os.getuid() == 0:
+    name = sys.argv[0].split('_')[-1]
+    pw_info = pwd.getpwnam(name)
+    pw_uid = pw_info[2]
+    pw_gid = pw_info[3]
+    other_gids = [grp_info.gr_gid
+                  for grp_info in grp.getgrall()
+                  if name in grp_info.gr_mem and grp_info.gr_gid != pw_gid]
+
+    # Determine which uid/gid we want to switch to. By default use current
+    # primary ones for the target user name.
+    target_uid = pw_uid
+    target_gid = pw_gid
+
+    try:
+        with open('/home/%s/.m2ee/m2ee.pid' % name, 'r') as f:
+            pid = int(f.read().strip())
+        stat_info = os.stat('/proc/%s' % pid)
+        # If we find a running process owned by this user, check if the primary
+        # group it has been started with is currently no longer the users
+        # primary group, but part of the supplementary group list.  If so, use
+        # it instead.
+        if stat_info.st_uid == pw_uid and stat_info.st_gid in other_gids:
+            target_gid = stat_info.st_gid
+            other_gids.remove(stat_info.st_gid)
+            other_gids.append(pw_gid)
+    except Exception as e:
+        # Just use the above default, since we can trust the name in argv[0].
+        # And, if the app is not running we don't care about smaps anyway.
+        pass
+
+    os.chdir('/')
+    os.setgroups(other_gids)
+    os.setregid(target_gid, target_gid)
+    os.setreuid(target_uid, target_uid)
+
+import logging  # noqa
+import m2ee  # noqa
 
 logger = logging.getLogger()
 logger.setLevel(logging.WARNING)


### PR DESCRIPTION
See commit. This needs to be rolled out before puppet UP_166_slot_primary_group, which again needs to be rolled out before m2ee-tools v7.2.