### PR TITLE
nginx_keystore_requests: support lua-mendix-keystore v0.6

### DIFF
--- a/plugins/nginx_keystore_requests
+++ b/plugins/nginx_keystore_requests
@@ -11,9 +11,16 @@ crt_info = [
     ('neg_cache_hit', 'Negative Cache Hit'),
     ('not_found', 'Not Found'),
 ]
+ca_info = [
+    ('cache_hit', 'Cache Hit'),
+    ('neg_cache_hit', 'Negative Cache Hit'),
+    ('ldap_hit', 'Keystore Hit'),
+    ('ldap_miss', 'Keystore Miss'),
+]
 
 
 def munin_config():
+    print('multigraph nginx_keystore_requests_crt')
     print("graph_title TLS Keystore Certificate lookups")
     print("graph_args --base 1000 -l 0")
     print("graph_vlabel hits")
@@ -28,11 +35,31 @@ def munin_config():
         print("{}.min 0".format(k))
     print("")
 
+    print('multigraph nginx_keystore_requests_ca')
+    print("graph_title TLS Keystore CA lookups")
+    print("graph_args --base 1000 -l 0")
+    print("graph_vlabel hits")
+    print("graph_category nginx")
+    print("graph_info This graph shows the number of TLS Keystore Hits/Misses "
+          "and (Negative) Cached CA Hits")
+    for k, v in ca_info:
+        print("{}.label {}".format(k, v))
+        print("{}.draw LINE1".format(k))
+        print("{}.info {}".format(k, v))
+        print("{}.type DERIVE".format(k))
+        print("{}.min 0".format(k))
+    print("")
+
 
 def munin_values():
     stats = requests.get('http://localhost:83/keystore/stats').json()
+    print('multigraph nginx_keystore_requests_crt')
     for k, _ in crt_info:
         print("{0}.value {1}".format(k, stats['crt'][k]))
+    print("")
+    print('multigraph nginx_keystore_requests_ca')
+    for k, _ in ca_info:
+        print("{0}.value {1}".format(k, stats['ca'][k]))
 
 
 def main():

--- a/plugins/nginx_keystore_requests
+++ b/plugins/nginx_keystore_requests
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-from __future__ import print_function
+from __future__ import print_function, division
 import requests
 import sys
 
@@ -62,6 +62,21 @@ def munin_config():
         print("{}.min 0".format(k))
     print("")
 
+    print('multigraph nginx_keystore_requests_memory')
+    print("graph_title TLS Keystore nginx shared memory object usage")
+    print("graph_args --upper-limit 100 -l 0")
+    print("graph_vlabel %")
+    print("graph_scale no")
+    print("graph_category nginx")
+    print("graph_info This graph shows the nginx shared memory object usage.")
+    for k in ["ca_cache", "crt_cache", "neg_ca_cache", "neg_crt_cache",
+              "tlsset_cache", "neg_tlsset_cache", "id_cache"]:
+        print("{}.label {}".format(k, k))
+        print("{}.draw LINE1".format(k))
+        print("{}.info {}".format(k, k))
+        print("{}.min 0".format(k))
+    print("")
+
 
 def munin_values():
     stats = requests.get('http://localhost:83/keystore/stats').json()
@@ -74,6 +89,13 @@ def munin_values():
     print('multigraph nginx_keystore_requests_ca')
     for k, _ in ca_info:
         print("{0}.value {1}".format(k, stats['ca'][k]))
+    print("")
+    print('multigraph nginx_keystore_requests_memory')
+    for k in ["crt_cache", "neg_crt_cache", "ca_cache", "neg_ca_cache",
+              "tlsset_cache", "neg_tlsset_cache", "id_cache"]:
+        percentage = round((stats['memory'][k]['capacity'] - stats['memory'][k]['free_space'])
+                           / stats['memory'][k]['capacity'] * 100, 2)
+        print("{0}.value {1}".format(k, percentage))
 
 
 def main():

--- a/plugins/nginx_keystore_requests
+++ b/plugins/nginx_keystore_requests
@@ -12,11 +12,11 @@ def munin_config():
     print("graph_category nginx")
     print("graph_info This graph shows the number of TLS Keystore Hits/Misses "
           "and (Negative) Cached Certificates Hits")
-    print("crt_cache_hit.label Cache Hit")
-    print("crt_cache_hit.draw LINE1")
-    print("crt_cache_hit.info Cache Hit")
-    print("crt_cache_hit.type DERIVE")
-    print("crt_cache_hit.min 0")
+    print("cache_hit.label Cache Hit")
+    print("cache_hit.draw LINE1")
+    print("cache_hit.info Cache Hit")
+    print("cache_hit.type DERIVE")
+    print("cache_hit.min 0")
     print("ldap_hit.label Keystore Hit")
     print("ldap_hit.draw LINE1")
     print("ldap_hit.info Keystore Hit")
@@ -27,11 +27,11 @@ def munin_config():
     print("ldap_miss.info Keystore Miss")
     print("ldap_miss.type DERIVE")
     print("ldap_miss.min 0")
-    print("neg_crt_cache_hit.label Negative Cache Hit")
-    print("neg_crt_cache_hit.draw LINE1")
-    print("neg_crt_cache_hit.info Negative Cache Hit")
-    print("neg_crt_cache_hit.type DERIVE")
-    print("neg_crt_cache_hit.min 0")
+    print("neg_cache_hit.label Negative Cache Hit")
+    print("neg_cache_hit.draw LINE1")
+    print("neg_cache_hit.info Negative Cache Hit")
+    print("neg_cache_hit.type DERIVE")
+    print("neg_cache_hit.min 0")
     print("not_found.label Not Found")
     print("not_found.draw LINE1")
     print("not_found.info Not Found")
@@ -41,8 +41,8 @@ def munin_config():
 
 def munin_values():
     stats = requests.get('http://localhost:83/keystore/stats').json()
-    for key in ['crt_cache_hit', 'ldap_hit', 'ldap_miss', 'neg_crt_cache_hit', 'not_found']:
-        print("{0}.value {1}".format(key, stats[key]))
+    for key in ['cache_hit', 'ldap_hit', 'ldap_miss', 'neg_cache_hit', 'not_found']:
+        print("{0}.value {1}".format(key, stats['crt'][key]))
 
 
 def main():
@@ -50,6 +50,7 @@ def main():
         munin_config()
     else:
         munin_values()
+
 
 if __name__ == "__main__":
     main()

--- a/plugins/nginx_keystore_requests
+++ b/plugins/nginx_keystore_requests
@@ -5,17 +5,13 @@ import requests
 import sys
 
 crt_info = [
-    ('cache_hit', 'Cache Hit'),
-    ('ldap_hit', 'Keystore Hit'),
-    ('ldap_miss', 'Keystore Miss'),
-    ('neg_cache_hit', 'Negative Cache Hit'),
-    ('not_found', 'Not Found'),
-]
-crt_wildcard_info = [
-    ('cache_hit', 'Wildcard Cache Hit'),
-    ('ldap_hit', 'Wildcard Keystore Hit'),
-    ('ldap_miss', 'Wildcard Keystore Miss'),
-    ('neg_cache_hit', 'Wildcard Negative Cache Hit'),
+    ('', 'cache_hit', 'Cache Hit'),
+    ('', 'neg_cache_hit', 'Negative Cache Hit'),
+    ('', 'ldap_hit', 'Keystore Hit'),
+    ('wildcard', 'cache_hit', 'Wildcard Cache Hit'),
+    ('wildcard', 'neg_cache_hit', 'Wildcard Negative Cache Hit'),
+    ('wildcard', 'ldap_hit', 'Wildcard Keystore Hit'),
+    ('', 'not_found', 'Not Found'),
 ]
 ca_info = [
     ('cache_hit', 'Cache Hit'),
@@ -33,18 +29,14 @@ def munin_config():
     print("graph_category nginx")
     print("graph_info This graph shows the number of TLS Keystore Hits/Misses "
           "and (Negative) Cached Certificates Hits")
-    for k, v in crt_info:
+    for p, k, v in crt_info:
+        if p != '':
+            k = '{}_{}'.format(p, k)
         print("{}.label {}".format(k, v))
         print("{}.draw LINE1".format(k))
         print("{}.info {}".format(k, v))
         print("{}.type DERIVE".format(k))
         print("{}.min 0".format(k))
-    for k, v in crt_wildcard_info:
-        print("wildcard_{}.label {}".format(k, v))
-        print("wildcard_{}.draw LINE1".format(k))
-        print("wildcard_{}.info {}".format(k, v))
-        print("wildcard_{}.type DERIVE".format(k))
-        print("wildcard_{}.min 0".format(k))
     print("")
 
     print('multigraph nginx_keystore_requests_ca')
@@ -81,10 +73,11 @@ def munin_config():
 def munin_values():
     stats = requests.get('http://localhost:83/keystore/stats').json()
     print('multigraph nginx_keystore_requests_crt')
-    for k, _ in crt_info:
-        print("{0}.value {1}".format(k, stats['crt'][k]))
-    for k, _ in crt_wildcard_info:
-        print("wildcard_{0}.value {1}".format(k, stats['crt_wildcard'][k]))
+    for p, k, _ in crt_info:
+        if p == '':
+            print("{0}.value {1}".format(k, stats['crt'][k]))
+        elif p == 'wildcard':
+            print("wildcard_{0}.value {1}".format(k, stats['crt_wildcard'][k]))
     print("")
     print('multigraph nginx_keystore_requests_ca')
     for k, _ in ca_info:

--- a/plugins/nginx_keystore_requests
+++ b/plugins/nginx_keystore_requests
@@ -4,45 +4,35 @@ from __future__ import print_function
 import requests
 import sys
 
+crt_info = [
+    ('cache_hit', 'Cache Hit'),
+    ('ldap_hit', 'Keystore Hit'),
+    ('ldap_miss', 'Keystore Miss'),
+    ('neg_cache_hit', 'Negative Cache Hit'),
+    ('not_found', 'Not Found'),
+]
+
 
 def munin_config():
+    print("graph_title TLS Keystore Certificate lookups")
     print("graph_args --base 1000 -l 0")
     print("graph_vlabel hits")
-    print("graph_title TLS Keystore lookups")
     print("graph_category nginx")
     print("graph_info This graph shows the number of TLS Keystore Hits/Misses "
           "and (Negative) Cached Certificates Hits")
-    print("cache_hit.label Cache Hit")
-    print("cache_hit.draw LINE1")
-    print("cache_hit.info Cache Hit")
-    print("cache_hit.type DERIVE")
-    print("cache_hit.min 0")
-    print("ldap_hit.label Keystore Hit")
-    print("ldap_hit.draw LINE1")
-    print("ldap_hit.info Keystore Hit")
-    print("ldap_hit.type DERIVE")
-    print("ldap_hit.min 0")
-    print("ldap_miss.label Keystore Miss")
-    print("ldap_miss.draw LINE1")
-    print("ldap_miss.info Keystore Miss")
-    print("ldap_miss.type DERIVE")
-    print("ldap_miss.min 0")
-    print("neg_cache_hit.label Negative Cache Hit")
-    print("neg_cache_hit.draw LINE1")
-    print("neg_cache_hit.info Negative Cache Hit")
-    print("neg_cache_hit.type DERIVE")
-    print("neg_cache_hit.min 0")
-    print("not_found.label Not Found")
-    print("not_found.draw LINE1")
-    print("not_found.info Not Found")
-    print("not_found.type DERIVE")
-    print("not_found.min 0")
+    for k, v in crt_info:
+        print("{}.label {}".format(k, v))
+        print("{}.draw LINE1".format(k))
+        print("{}.info {}".format(k, v))
+        print("{}.type DERIVE".format(k))
+        print("{}.min 0".format(k))
+    print("")
 
 
 def munin_values():
     stats = requests.get('http://localhost:83/keystore/stats').json()
-    for key in ['cache_hit', 'ldap_hit', 'ldap_miss', 'neg_cache_hit', 'not_found']:
-        print("{0}.value {1}".format(key, stats['crt'][key]))
+    for k, _ in crt_info:
+        print("{0}.value {1}".format(k, stats['crt'][k]))
 
 
 def main():

--- a/plugins/nginx_keystore_requests
+++ b/plugins/nginx_keystore_requests
@@ -11,6 +11,12 @@ crt_info = [
     ('neg_cache_hit', 'Negative Cache Hit'),
     ('not_found', 'Not Found'),
 ]
+crt_wildcard_info = [
+    ('cache_hit', 'Wildcard Cache Hit'),
+    ('ldap_hit', 'Wildcard Keystore Hit'),
+    ('ldap_miss', 'Wildcard Keystore Miss'),
+    ('neg_cache_hit', 'Wildcard Negative Cache Hit'),
+]
 ca_info = [
     ('cache_hit', 'Cache Hit'),
     ('neg_cache_hit', 'Negative Cache Hit'),
@@ -33,6 +39,12 @@ def munin_config():
         print("{}.info {}".format(k, v))
         print("{}.type DERIVE".format(k))
         print("{}.min 0".format(k))
+    for k, v in crt_wildcard_info:
+        print("wildcard_{}.label {}".format(k, v))
+        print("wildcard_{}.draw LINE1".format(k))
+        print("wildcard_{}.info {}".format(k, v))
+        print("wildcard_{}.type DERIVE".format(k))
+        print("wildcard_{}.min 0".format(k))
     print("")
 
     print('multigraph nginx_keystore_requests_ca')
@@ -56,6 +68,8 @@ def munin_values():
     print('multigraph nginx_keystore_requests_crt')
     for k, _ in crt_info:
         print("{0}.value {1}".format(k, stats['crt'][k]))
+    for k, _ in crt_wildcard_info:
+        print("wildcard_{0}.value {1}".format(k, stats['crt_wildcard'][k]))
     print("")
     print('multigraph nginx_keystore_requests_ca')
     for k, _ in ca_info:


### PR DESCRIPTION
In lua-mendix-keystore v0.4 the `/keystore/stats` format changed.